### PR TITLE
feat: Section.to_the_right and Section.below ignore empty sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # XLSXComposer
-
-**TODO: Add description**
+An wrapper arround `elixlsx` that focuses on readability and performance (`elixlsx` suffers big penalties when using a lot of `set_cell/2`)
 
 ## Installation
 
@@ -10,7 +9,7 @@ by adding `xlsx_composer` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:xlsx_composer, "~> 0.1.0"}
+    {:xlsx_composer, "~> 0.3.0"}
   ]
 end
 ```

--- a/lib/xlsx_composer/section.ex
+++ b/lib/xlsx_composer/section.ex
@@ -83,12 +83,15 @@ defmodule XLSXComposer.Section do
   |E1|TB|E3|E4|E5|
   ----------------
   """
-  @spec just_below(Section.t()) :: ExcelCoords.t()
-  def just_below(%Section{} = section, opts \\ []) do
+  @spec below(Section.t()) :: ExcelCoords.t()
+  def below(%Section{} = section, opts \\ []) do
     move_x = Keyword.get(opts, :move_x, 0)
     move_y = Keyword.get(opts, :move_y, 0)
 
-    ExcelCoords.new(section.top_left.x + move_x, section.bottom_right.y + 1 + move_y)
+    ExcelCoords.new(
+      section.top_left.x + move_x,
+      section.bottom_right.y + move_y_just_below(section) + move_y
+    )
   end
 
   @doc """
@@ -109,12 +112,15 @@ defmodule XLSXComposer.Section do
   |E1|E2|E3|E4|E5|
   ----------------
   """
-  @spec just_to_the_right(Section.t()) :: ExcelCoords.t()
-  def just_to_the_right(%Section{} = section, opts \\ []) do
+  @spec to_the_right(Section.t()) :: ExcelCoords.t()
+  def to_the_right(%Section{} = section, opts \\ []) do
     move_x = Keyword.get(opts, :move_x, 0)
     move_y = Keyword.get(opts, :move_y, 0)
 
-    ExcelCoords.new(section.bottom_right.x + 1 + move_x, section.bottom_right.y + move_y)
+    ExcelCoords.new(
+      section.bottom_right.x + move_x_just_right(section) + move_x,
+      section.top_left.y + move_y
+    )
   end
 
   @spec reduce_to_excel_cells([Section.t()]) :: CellDef.excel_cells()
@@ -153,6 +159,32 @@ defmodule XLSXComposer.Section do
     end)
     |> Map.new()
   end
+
+  @doc """
+  Identifies by how much you have to move the y value of the new Section's `top_left` point to just below another section.
+  Simply: A scenario: you want to find the `top_left` point of section_2 based of the section_1 (which is a reference here).
+  If section_1 is empty, then section_2 can start from the same `top_left`, so move by 0.
+  Otherwise, we have to move by 1.
+  """
+  @spec move_y_just_below(Section.t()) :: 0 | 1
+  def move_y_just_below(%Section{top_left: top_left, bottom_right: bottom_right} = _section)
+      when top_left == bottom_right,
+      do: 0
+
+  def move_y_just_below(%Section{} = _section), do: 1
+
+  @doc """
+  Identifies by how much you have to move the x value of the new Section's `top_left` point to just right another section.
+  Simply: A scenario: you want to find the `top_left` point of section_2 based of the section_1 (which is a reference here).
+  If section_1 is empty, then section_2 can start from the same `top_left`, so move by 0.
+  Otherwise, we have to move by 1.
+  """
+  @spec move_x_just_right(Section.t()) :: 0 | 1
+  def move_x_just_right(%Section{top_left: top_left, bottom_right: bottom_right} = _section)
+      when top_left == bottom_right,
+      do: 0
+
+  def move_x_just_right(%Section{} = _section), do: 1
 
   @spec pick_higher_int(non_neg_integer(), non_neg_integer()) :: non_neg_integer()
   defp pick_higher_int(int_1, int_2) when int_1 > int_2, do: int_1

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XLSXComposer.MixProject do
   def project do
     [
       app: :xlsx_composer,
-      version: "0.2.0",
+      version: "0.3.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/xlsx_composer/section_test.exs
+++ b/test/xlsx_composer/section_test.exs
@@ -322,29 +322,27 @@ defmodule XLSXComposer.SectionTest do
     end
   end
 
-  describe "just_below/1 and just_below/2" do
-    test "just below to an empty section" do
+  describe "below/1 and just_below/2" do
+    test "below to an empty section" do
       top_left = ExcelCoords.new(1, 1)
       bottom_right = ExcelCoords.new(1, 1)
 
-      # Correct just below point will jump one cell below the original top_left
-      # opts are not supplied so the default is (0, 0)
-      correct_just_below = ExcelCoords.new(1, 2)
+      # Correct just below point is one cell below the section above if the section above is not empty.
+      correct_just_below = ExcelCoords.new(1, 1)
 
       assert correct_just_below ===
                %Section{
                  top_left: top_left,
                  bottom_right: bottom_right
                }
-               |> Section.just_below()
+               |> Section.below()
     end
 
-    test "just below to an non-empty section" do
+    test "below to an non-empty section" do
       top_left = ExcelCoords.new(1, 1)
       bottom_right = ExcelCoords.new(3, 3)
 
-      # Correct just below point will jump one cell below the original top_left
-      # opts are not supplied so the default is (0, 0)
+      # Correct just below point is one cell below the section above if the section above is not empty.
       correct_just_below = ExcelCoords.new(1, 4)
 
       assert correct_just_below ===
@@ -352,70 +350,68 @@ defmodule XLSXComposer.SectionTest do
                  top_left: top_left,
                  bottom_right: bottom_right
                }
-               |> Section.just_below()
+               |> Section.below()
     end
 
-    test "just below to an empty section, with opts" do
+    test "below to an empty section with opts" do
       top_left = ExcelCoords.new(1, 1)
       bottom_right = ExcelCoords.new(1, 1)
 
-      # Correct just below point will jump one cell below the original top_left
-      # opts are supplied
-      correct_just_below = ExcelCoords.new(2, 4)
+      # Correct just below point is one cell below the section above if the section above is not empty.
+      correct_just_below = ExcelCoords.new(3, 3)
 
       assert correct_just_below ===
                %Section{
                  top_left: top_left,
                  bottom_right: bottom_right
                }
-               |> Section.just_below(move_x: 1, move_y: 2)
+               |> Section.below(move_x: 2, move_y: 2)
     end
 
-    test "just below to an non-empty section, with opts" do
+    test "below to an non-empty section with opts" do
       top_left = ExcelCoords.new(1, 1)
       bottom_right = ExcelCoords.new(3, 3)
 
-      # Correct just below point will jump one cell below the original top_left
-      # opts are supplied
-      correct_just_below = ExcelCoords.new(2, 7)
+      # Correct just below point is one cell below the section above if the section above is not empty.
+      correct_just_below = ExcelCoords.new(3, 6)
 
       assert correct_just_below ===
                %Section{
                  top_left: top_left,
                  bottom_right: bottom_right
                }
-               |> Section.just_below(move_x: 1, move_y: 3)
+               |> Section.below(move_x: 2, move_y: 2)
     end
   end
 
-  describe "just_to_the_right/0 and just_to_the_right/2" do
-    test "just_to_the_right to an empty section" do
+  describe "to_the_right/1 and just_to_the_right/2" do
+    test "to_the_right to an empty section" do
       top_left = ExcelCoords.new(1, 1)
       bottom_right = ExcelCoords.new(1, 1)
-      correct_just_to_the_right = ExcelCoords.new(2, 1)
+      correct_just_to_the_right = ExcelCoords.new(1, 1)
 
       assert correct_just_to_the_right ===
                %Section{
                  top_left: top_left,
                  bottom_right: bottom_right
                }
-               |> Section.just_to_the_right()
+               |> Section.to_the_right()
     end
 
-    test "just_to_the_right to an non-empty section" do
+    test "to_the_right to an non-empty section" do
       top_left = ExcelCoords.new(1, 1)
       bottom_right = ExcelCoords.new(3, 3)
-      correct_just_to_the_right = ExcelCoords.new(4, 3)
+      correct_just_to_the_right = ExcelCoords.new(4, 1)
 
       assert correct_just_to_the_right ===
                %Section{
                  top_left: top_left,
                  bottom_right: bottom_right
                }
-               |> Section.just_to_the_right()
+               |> Section.to_the_right()
     end
 
-    test "just below to an empty section, with opts" do
+    test "to_the_right to an empty section with opts" do
       top_left = ExcelCoords.new(1, 1)
       bottom_right = ExcelCoords.new(1, 1)
       correct_just_to_the_right = ExcelCoords.new(3, 3)
@@ -425,20 +421,20 @@ defmodule XLSXComposer.SectionTest do
                  top_left: top_left,
                  bottom_right: bottom_right
                }
-               |> Section.just_to_the_right(move_x: 1, move_y: 2)
+               |> Section.to_the_right(move_x: 2, move_y: 2)
     end
 
-    test "just below to an non-empty section, with opts" do
+    test "to_the_right to an non-empty section with opts" do
       top_left = ExcelCoords.new(1, 1)
       bottom_right = ExcelCoords.new(3, 3)
-      correct_just_to_the_right = ExcelCoords.new(5, 6)
+      correct_just_to_the_right = ExcelCoords.new(6, 3)
 
       assert correct_just_to_the_right ===
                %Section{
                  top_left: top_left,
                  bottom_right: bottom_right
                }
-               |> Section.just_to_the_right(move_x: 1, move_y: 3)
+               |> Section.to_the_right(move_x: 2, move_y: 2)
     end
   end
 end


### PR DESCRIPTION
Now, `below` and `to_the_right` ignore empty Section(s) in order to focus on API that focuses on testing Sections and scenarios in which they could be empty and easy composition. Now, it will be guaranteed that sections are directly below each other and testing edge cases when they could be empty, f.e. if an enumerable used to create rows is empty.